### PR TITLE
Best practices in .NET and driver usage.

### DIFF
--- a/RethinkDemoWindows/Startup.cs
+++ b/RethinkDemoWindows/Startup.cs
@@ -55,12 +55,12 @@ namespace RethinkDemoWindows
     {
         public static RethinkDB r = RethinkDB.r;
 
-        public static async Task HandleUpdates()
+        public static void HandleUpdates()
         {
             var hub = GlobalHost.ConnectionManager.GetHubContext<ChatHub>();
             var conn = r.connection().connect();
-            var feed = await r.db("test").table("chat")
-                              .changes().runChangesAsync<ChatMessage>(conn);
+            var feed = r.db("test").table("chat")
+                              .changes().runChanges<ChatMessage>(conn);
 
             foreach (var message in feed)
                 hub.Clients.All.onMessage(

--- a/RethinkDemoWindows/Startup.cs
+++ b/RethinkDemoWindows/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNet.SignalR;
 using RethinkDb.Driver;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+using RethinkDb.Driver.Net;
 
 [assembly: OwinStartup(typeof(RethinkDemoWindows.Startup))]
 
@@ -21,45 +22,47 @@ namespace RethinkDemoWindows
     public class ChatHub : Hub
     {
         public static RethinkDB r = RethinkDB.r;
+        static Connection conn;
+
+        internal static void Init()
+        {
+            conn = r.connection().connect();
+        }
 
         public void Send(string name, string message)
         {
-            var conn = r.connection().connect();
             r.db("test").table("chat")
              .insert(new ChatMessage {
                  username = name,
                  message = message,
                  timestamp = DateTime.Now
              }).run(conn);
-            conn.close();
         }
 
         public JArray History(int limit)
         {
-            var conn = r.connection().connect();
             var output = r.db("test").table("chat")
                           .orderBy(r.desc("timestamp"))
                           .limit(limit)
                           .orderBy("timestamp")
                           .coerceTo("array")
                           .run<JObject>(conn);
-            conn.close();
             return output;
         }
     }
 
-    class ChangeHandler
+    static class ChangeHandler
     {
         public static RethinkDB r = RethinkDB.r;
 
-        async public void handleUpdates()
+        public static async Task HandleUpdates()
         {
             var hub = GlobalHost.ConnectionManager.GetHubContext<ChatHub>();
             var conn = r.connection().connect();
-            var feed = r.db("test").table("chat")
-                        .changes().runChangesAsync<ChatMessage>(conn);
+            var feed = await r.db("test").table("chat")
+                              .changes().runChangesAsync<ChatMessage>(conn);
 
-            foreach (var message in await feed)
+            foreach (var message in feed)
                 hub.Clients.All.onMessage(
                     message.NewValue.username,
                     message.NewValue.message,
@@ -71,7 +74,12 @@ namespace RethinkDemoWindows
     {
         public void Configuration(IAppBuilder app)
         {
-            new ChangeHandler().handleUpdates();
+            ChatHub.Init();
+
+            Task.Factory.StartNew(
+                ChangeHandler.HandleUpdates,
+                TaskCreationOptions.LongRunning);
+            
             app.MapSignalR();
         }
     }


### PR DESCRIPTION
Hey there!
Really awesome blog post today! Congrats to all for the Windows build! :+1: 

I noticed just few issues in the examples... So, I thought of some improvements we could make:

```
async public void handleUpdates()
   foreach (var message in await feed)            
           hub.Clients.All.onMessage(               
               message.NewValue.username,           
               message.NewValue.message,              
              message.NewValue.timestamp);        
   }
```

I don't think it is common in .NET to use `await` in side the `foreach` loop. Normally, `await` is used to directly **await** a result from an `*Async(...)` method call. Also, IIRC, `async void` shouldn't be used and is usually only acceptable in `async void` `event` handlers.

```
var feed = await r.db("test").table("chat")
                  .changes().runChangesAsync<ChatMessage>(conn);
```

Essentially, what the code is doing here is asynchronously awaiting on the establishment of a cursor object `feed` that can be readily consumed by the `foreach` loop synchronously. This doesn't asynchronously consume changes on an per item basis.

The most simple form of consuming change feeds is using a dedicated `Task`(thread) as a pump to push the cursor changes to the client over **SignalR** because each iteration of the `foreach` loop is a blocking (synchronous) operation when we are waiting on changes coming down from the server. If you would like to make _consumption_ of change items to be asynchronous, then you need to manually drive the consumption items using a `while` loop and `await MoveNextAsync` because there's no .NET convention to consume `IEnumerable` asynchronously. `IEnumerable` (and as a consequence using `foreach`) in .NET is inherently a synchronous operation.

My apologies, this was my mistake and I should make this a bit more clear/explicit in the documentation for processing change feeds.

Also, [connections & connection pools are expensive](https://github.com/bchavez/RethinkDb.Driver/wiki/Connections-&-Pooling#connection-lifetime) and we should be using them in a singleton lifestyle instead of open/closing connections per request.

I hope this helps!
Brian

Update: Simplified the example by removing `async`.
