### PR TITLE
Removed coerceTo("array"). Added ChatHubAsync example.

### DIFF
--- a/RethinkDemoWindows/ChatHub.cs
+++ b/RethinkDemoWindows/ChatHub.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.AspNet.SignalR;
+using Newtonsoft.Json.Linq;
+using RethinkDb.Driver;
+using RethinkDb.Driver.Net;
+
+namespace RethinkDemoWindows
+{
+    public class ChatHub : Hub
+    {
+        public static RethinkDB r = RethinkDB.r;
+        static Connection conn;
+
+        internal static void Init()
+        {
+            conn = r.connection().connect();
+        }
+
+        public void Send(string name, string message)
+        {
+            r.db("test").table("chat")
+                .insert(new ChatMessage {
+                    username = name,
+                    message = message,
+                    timestamp = DateTime.Now
+                }).run(conn);
+        }
+
+        public JArray History(int limit)
+        {
+            var output = r.db("test").table("chat")
+                .orderBy(r.desc("timestamp"))
+                .limit(limit)
+                .orderBy("timestamp")
+                .runResult<JArray>(conn);
+            return output;
+        }
+    }
+}

--- a/RethinkDemoWindows/ChatHubAsync.cs
+++ b/RethinkDemoWindows/ChatHubAsync.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR;
+using Newtonsoft.Json.Linq;
+using RethinkDb.Driver;
+using RethinkDb.Driver.Net;
+
+namespace RethinkDemoWindows
+{
+    public class ChatHubAsync : Hub
+    {
+        public static RethinkDB r = RethinkDB.r;
+        static Connection conn;
+
+        internal static async Task Init()
+        {
+            conn = await r.connection().connectAsync();
+        }
+
+        public async Task Send(string name, string message)
+        {
+            await r.db("test").table("chat")
+                    .insert(new ChatMessage
+                    {
+                        username = name,
+                        message = message,
+                        timestamp = DateTime.Now
+                    }).runResultAsync(conn);
+        }
+
+        public async Task<JArray> History(int limit)
+        {
+            return await r.db("test").table("chat")
+                    .orderBy(r.desc("timestamp"))
+                    .limit(limit)
+                    .orderBy("timestamp")
+                    .runResultAsync<JArray>(conn);
+        }
+    }
+}

--- a/RethinkDemoWindows/RethinkDemoWindows.csproj
+++ b/RethinkDemoWindows/RethinkDemoWindows.csproj
@@ -162,6 +162,8 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChatHub.cs" />
+    <Compile Include="ChatHubAsync.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/RethinkDemoWindows/Startup.cs
+++ b/RethinkDemoWindows/Startup.cs
@@ -4,9 +4,7 @@ using Microsoft.Owin;
 using Owin;
 using Microsoft.AspNet.SignalR;
 using RethinkDb.Driver;
-using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
-using RethinkDb.Driver.Net;
 
 [assembly: OwinStartup(typeof(RethinkDemoWindows.Startup))]
 
@@ -17,38 +15,6 @@ namespace RethinkDemoWindows
         public string username { get; set; }
         public string message { get; set; }
         public DateTime timestamp { get; set; }
-    }
-
-    public class ChatHub : Hub
-    {
-        public static RethinkDB r = RethinkDB.r;
-        static Connection conn;
-
-        internal static void Init()
-        {
-            conn = r.connection().connect();
-        }
-
-        public void Send(string name, string message)
-        {
-            r.db("test").table("chat")
-             .insert(new ChatMessage {
-                 username = name,
-                 message = message,
-                 timestamp = DateTime.Now
-             }).run(conn);
-        }
-
-        public JArray History(int limit)
-        {
-            var output = r.db("test").table("chat")
-                          .orderBy(r.desc("timestamp"))
-                          .limit(limit)
-                          .orderBy("timestamp")
-                          .coerceTo("array")
-                          .run<JObject>(conn);
-            return output;
-        }
     }
 
     static class ChangeHandler
@@ -75,6 +41,8 @@ namespace RethinkDemoWindows
         public void Configuration(IAppBuilder app)
         {
             ChatHub.Init();
+            //Best we can do without async void 
+            //ChatHubAsync.Init().Wait();
 
             Task.Factory.StartNew(
                 ChangeHandler.HandleUpdates,


### PR DESCRIPTION
Hello,

I'm starting to get .NET devs asking about making the blog post and making examples better.

https://github.com/bchavez/RethinkDb.Driver/issues/26

This PR is a move toward in that direction. It provides a fully async `ChatHub` example using the driver.

If it is possible, I think it would be really good if the blog post could be updated and corrected with the latest changes before we upset the apple cart too much. :apple:

Also, I removed `coerceTo("array")` from the `History` query. After checking the shape of the returned results, I don't think it was necessary with the C# driver.

I hope this helps! Thanks again, Brian.
