### PR TITLE
ReQL AST with .NET conventions.

### DIFF
--- a/RethinkDemoWindows/ChatHub.cs
+++ b/RethinkDemoWindows/ChatHub.cs
@@ -8,31 +8,31 @@ namespace RethinkDemoWindows
 {
     public class ChatHub : Hub
     {
-        public static RethinkDB r = RethinkDB.r;
+        public static RethinkDB R = RethinkDB.R;
         static Connection conn;
 
         internal static void Init()
         {
-            conn = r.connection().connect();
+            conn = R.Connection().Connect();
         }
 
         public void Send(string name, string message)
         {
-            r.db("test").table("chat")
-                .insert(new ChatMessage {
+            R.Db("test").Table("chat")
+                .Insert(new ChatMessage {
                     username = name,
                     message = message,
                     timestamp = DateTime.Now
-                }).run(conn);
+                }).Run(conn);
         }
 
         public JArray History(int limit)
         {
-            var output = r.db("test").table("chat")
-                .orderBy(r.desc("timestamp"))
-                .limit(limit)
-                .orderBy("timestamp")
-                .runResult<JArray>(conn);
+            var output = R.Db("test").Table("chat")
+                .OrderBy(R.Desc("timestamp"))
+                .Limit(limit)
+                .OrderBy("timestamp")
+                .RunResult<JArray>(conn);
             return output;
         }
     }

--- a/RethinkDemoWindows/ChatHubAsync.cs
+++ b/RethinkDemoWindows/ChatHubAsync.cs
@@ -9,32 +9,32 @@ namespace RethinkDemoWindows
 {
     public class ChatHubAsync : Hub
     {
-        public static RethinkDB r = RethinkDB.r;
+        public static RethinkDB R = RethinkDB.R;
         static Connection conn;
 
         internal static async Task Init()
         {
-            conn = await r.connection().connectAsync();
+            conn = await R.Connection().ConnectAsync();
         }
 
         public async Task Send(string name, string message)
         {
-            await r.db("test").table("chat")
-                    .insert(new ChatMessage
+            await R.Db("test").Table("chat")
+                    .Insert(new ChatMessage
                     {
                         username = name,
                         message = message,
                         timestamp = DateTime.Now
-                    }).runResultAsync(conn);
+                    }).RunResultAsync(conn);
         }
 
         public async Task<JArray> History(int limit)
         {
-            return await r.db("test").table("chat")
-                    .orderBy(r.desc("timestamp"))
-                    .limit(limit)
-                    .orderBy("timestamp")
-                    .runResultAsync<JArray>(conn);
+            return await R.Db("test").Table("chat")
+                    .OrderBy(R.Desc("timestamp"))
+                    .Limit(limit)
+                    .OrderBy("timestamp")
+                    .RunResultAsync<JArray>(conn);
         }
     }
 }

--- a/RethinkDemoWindows/RethinkDemoWindows.csproj
+++ b/RethinkDemoWindows/RethinkDemoWindows.csproj
@@ -116,8 +116,8 @@
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RethinkDb.Driver, Version=2.2.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RethinkDb.Driver.2.2.4\lib\net45\RethinkDb.Driver.dll</HintPath>
+    <Reference Include="RethinkDb.Driver, Version=2.2.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RethinkDb.Driver.2.2.5-beta-3\lib\net45\RethinkDb.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.DynamicData" />

--- a/RethinkDemoWindows/RethinkDemoWindows.csproj
+++ b/RethinkDemoWindows/RethinkDemoWindows.csproj
@@ -116,8 +116,8 @@
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RethinkDb.Driver, Version=2.2.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RethinkDb.Driver.2.2.7\lib\net45\RethinkDb.Driver.dll</HintPath>
+    <Reference Include="RethinkDb.Driver, Version=2.2.10.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RethinkDb.Driver.2.2.10\lib\net45\RethinkDb.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.DynamicData" />

--- a/RethinkDemoWindows/RethinkDemoWindows.csproj
+++ b/RethinkDemoWindows/RethinkDemoWindows.csproj
@@ -116,8 +116,8 @@
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="RethinkDb.Driver, Version=2.2.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\RethinkDb.Driver.2.2.5-beta-3\lib\net45\RethinkDb.Driver.dll</HintPath>
+    <Reference Include="RethinkDb.Driver, Version=2.2.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RethinkDb.Driver.2.2.7\lib\net45\RethinkDb.Driver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.DynamicData" />

--- a/RethinkDemoWindows/Startup.cs
+++ b/RethinkDemoWindows/Startup.cs
@@ -19,14 +19,14 @@ namespace RethinkDemoWindows
 
     static class ChangeHandler
     {
-        public static RethinkDB r = RethinkDB.r;
+        public static RethinkDB R = RethinkDB.R;
 
         public static void HandleUpdates()
         {
             var hub = GlobalHost.ConnectionManager.GetHubContext<ChatHub>();
-            var conn = r.connection().connect();
-            var feed = r.db("test").table("chat")
-                              .changes().runChanges<ChatMessage>(conn);
+            var conn = R.Connection().Connect();
+            var feed = R.Db("test").Table("chat")
+                              .Changes().RunChanges<ChatMessage>(conn);
 
             foreach (var message in feed)
                 hub.Clients.All.onMessage(

--- a/RethinkDemoWindows/packages.config
+++ b/RethinkDemoWindows/packages.config
@@ -23,5 +23,5 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
-  <package id="RethinkDb.Driver" version="2.2.5-beta-3" targetFramework="net452" />
+  <package id="RethinkDb.Driver" version="2.2.7" targetFramework="net452" />
 </packages>

--- a/RethinkDemoWindows/packages.config
+++ b/RethinkDemoWindows/packages.config
@@ -23,5 +23,5 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
-  <package id="RethinkDb.Driver" version="2.2.4" targetFramework="net452" />
+  <package id="RethinkDb.Driver" version="2.2.5-beta-3" targetFramework="net452" />
 </packages>

--- a/RethinkDemoWindows/packages.config
+++ b/RethinkDemoWindows/packages.config
@@ -23,5 +23,5 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
-  <package id="RethinkDb.Driver" version="2.2.7" targetFramework="net452" />
+  <package id="RethinkDb.Driver" version="2.2.10" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Greetings. By popular demand, the C#/.NET driver is now using .NET conventions in the ReQL AST. All public APIs are now following proper C# naming conventions.

Available on NuGet starting at [2.2.5-beta-3](https://www.nuget.org/packages/RethinkDb.Driver/2.2.5-beta-3) and onward.
